### PR TITLE
ServiceMonitor to include scheme in the definition

### DIFF
--- a/operator/prometheus/prometheus/service_monitor.yaml
+++ b/operator/prometheus/prometheus/service_monitor.yaml
@@ -10,3 +10,4 @@ spec:
       application: ex-aao-app
   endpoints:
   - port: wconsj
+    scheme: http


### PR DESCRIPTION
Without `scheme: http` ServiceMonitor example would not be functional, as metrics are exposed using http. 